### PR TITLE
Removing file dump for JSON

### DIFF
--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -22,6 +22,8 @@ import random
 import math
 import netaddr
 
+import json
+
 import networkx
 
 from faucet import faucet_pipeline
@@ -762,6 +764,9 @@ configuration.
                 key=edge_name, port_map=edge_attr)
         elif (edge_a_dp.name, edge_z_dp.name, edge_name) in graph.edges:
             graph.remove_edge(edge_a_dp.name, edge_z_dp.name, edge_name)
+
+        with open('/etc/faucet/dp_graph.json', 'w') as outfile:
+            outfile.write(json.dumps(networkx.json_graph.node_link_data(graph), default=str))
 
         return edge_name
 


### PR DESCRIPTION
Dumping JSON as str to avoid "not serializable" exception. This should fix current Travis build failures in daq as well.